### PR TITLE
Add NSS examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 The repository contains example applications which demonstrate how to use
 wolfPKCS11. wolfPKCS11 is a lightweight PKCS11 soft token which uses wolfCrypt
 for the cryptographic functionality.
+
+## Contents
+
+* nss - Examples using wolfPKCS11 as the crypto backend for NSS.
+  - curl - Example using Curl with NSS and wolfPKCS11
+  - pdfsig - Example using pdfsig with NSS and wolfPKCS11 for signing PDFs
+  - firefox - Example using wolfPKCS11 as the crypto backend for Firefox's TLS
+    connections

--- a/nss/curl/Dockerfile
+++ b/nss/curl/Dockerfile
@@ -1,0 +1,165 @@
+FROM ubuntu:22.04
+
+# Set non-interactive mode for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies for NSS, curl, wolfSSL, and wolfPKCS11
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    mercurial \
+    gyp \
+    ninja-build \
+    pkg-config \
+    zlib1g-dev \
+    wget \
+    python3 \
+    python-is-python3 \
+    python3-pip \
+    autoconf \
+    automake \
+    libtool \
+    make \
+    gdb \
+    vim \
+    ca-certificates \
+    zlib1g-dev \
+    libnss3-tools \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /src
+
+# Clone NSS and NSPR repositories in the correct structure
+RUN mkdir -p /src && \
+    cd /src && \
+    hg clone https://hg.mozilla.org/projects/nspr && \
+    hg clone https://hg.mozilla.org/projects/nss
+
+
+# Clone OSP for NSS patches
+WORKDIR /src
+RUN git clone https://github.com/wolfSSL/osp.git
+
+# Build NSS with debug mode enabled (debug is the default)
+WORKDIR /src/nss
+ENV USE_64=1
+ENV NSS_ENABLE_WERROR=0
+ENV BUILD_OPT=0
+
+# Checkout our branch
+RUN patch -p1 < /src/osp/nss/nss-ecc-curves.patch
+RUN patch -p1 < /src/osp/nss/nss-slot.patch
+
+# Build NSS with debug mode enabled (debug is the default)
+RUN ./build.sh -v
+
+# Clone and build wolfSSL
+WORKDIR /src
+RUN git clone https://github.com/wolfSSL/wolfssl.git --depth=1 && \
+    cd wolfssl && \
+    ./autogen.sh && \
+    ./configure \
+      --enable-all \
+      --enable-debug \
+      --enable-aescfb \
+      --enable-cryptocb \
+      --enable-rsapss \
+      --enable-keygen \
+      --enable-pwdbased \
+      --enable-scrypt \
+      CFLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -D_GNU_SOURCE" && \
+    make && \
+    make install && \
+    ldconfig
+
+# Clone and build wolfPKCS11
+WORKDIR /src
+RUN git clone https://github.com/wolfSSL/wolfPKCS11.git && \
+    cd wolfPKCS11 && \
+    git checkout nss && \
+    ./autogen.sh && \
+    CFLAGS="-D_GNU_SOURCE" ./configure --enable-debug --enable-nss --enable-aesecb --enable-aesctr --enable-aesccm --enable-aescmac && \
+    make && \
+    make install && \
+    ldconfig && \
+    ls -la /usr/local/lib/libwolfpkcs11.so
+
+# Create NSS database directory structure
+RUN mkdir -p /etc/pki/nssdb
+
+# Configure NSS to use wolfPKCS11
+RUN echo "library=/usr/local/lib/libwolfpkcs11.so" > /etc/pki/nssdb/pkcs11.txt && \
+    echo "name=wolfPKCS11" >> /etc/pki/nssdb/pkcs11.txt && \
+    echo "NSS=Flags=internal,critical cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] }" >> /etc/pki/nssdb/pkcs11.txt && \
+    echo "" >> /etc/pki/nssdb/pkcs11.txt
+
+# Download and extract curl 8.0.0
+WORKDIR /src
+RUN wget --progress=dot:giga https://curl.se/download/curl-8.0.0.tar.gz && \
+    tar -xzf curl-8.0.0.tar.gz && \
+    rm curl-8.0.0.tar.gz
+
+# Copy NSS and NSPR headers and libraries from dist directory
+RUN mkdir -p /usr/local/include/nss && \
+    mkdir -p /usr/local/include/nspr && \
+    # Copy NSS headers from dist directory
+    cp -r /src/dist/public/nss/* /usr/local/include/nss/ && \
+    # Copy NSPR headers from dist directory
+    cp -r /src/dist/Debug/include/nspr/* /usr/local/include/nspr/ && \
+    # Copy NSS and NSPR libraries
+    mkdir -p /usr/local/lib && \
+    find /src/dist/Debug -name "*.so" -exec cp {} /usr/local/lib/ \; && \
+    find /src/nspr/Debug -name "*.so" -exec cp {} /usr/local/lib/ \; && \
+    ldconfig
+
+# Build curl with NSS support
+WORKDIR /src/curl-8.0.0
+
+# Set up environment for curl build
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV CPPFLAGS="-I/usr/local/include/nss -I/usr/local/include/nspr -I/usr/local/include"
+ENV LDFLAGS="-L/usr/local/lib"
+# Fix NSS include paths
+RUN mkdir -p /usr/include/nss && \
+    cp -r /usr/local/include/nss/* /usr/include/nss/ && \
+    mkdir -p /usr/include/nspr && \
+    cp -r /usr/local/include/nspr/* /usr/include/nspr/
+
+# Configure and build curl with NSS support
+RUN ./configure --with-nss=/usr/local --with-nss-deprecated && \
+    make -j"$(nproc)" && \
+    make install && \
+    ldconfig
+
+# Verify curl was built with NSS
+RUN curl -V | grep NSS
+
+# Set NSS debug environment variables
+ENV NSS_DEBUG_PKCS11_MODULE="wolfPKCS11"
+ENV NSPR_LOG_MODULES="all:5"
+ENV NSPR_LOG_FILE=/logs/nss.log
+ENV NSS_OUTPUT_FILE=/logs/stats.log
+ENV NSS_STRICT_NOFORK=1
+ENV NSS_DEBUG=all
+
+# Create logs directory
+RUN mkdir -p /logs
+
+# Default command to run curl with NSS debugging and capture errors
+CMD ["sh", "-c", "echo 'Testing curl with wolfPKCS11:' && \
+                  echo 'NSS using wolfPKCS11 from pkcs11.txt:' && \
+                  cat /etc/pki/nssdb/pkcs11.txt && \
+                  echo 'Setting up NSS debugging:' && \
+                  echo 'NSS_DEBUG_PKCS11_MODULE=\"NSS Internal PKCS #11 Module\"' && \
+                  echo 'NSPR_LOG_MODULES=\"nss_mod_log:4,pkcs11module:4,pk11mod:4,secmod:4\"' && \
+                  echo 'NSPR_LOG_FILE=/logs/nss.log' && \
+                  echo 'NSS_DEBUG=all' && \
+                  echo 'NSS_STRICT_NOFORK=1' && \
+                  echo 'Running curl against https://example.com/ (may crash, which is expected):' && \
+                  touch /logs/nss.log && chmod 666 /logs/nss.log && \
+                  curl -v https://example.com/ || echo 'Curl exited with error code $?' && \
+                  ls -la /logs && \
+                  cat /logs/nss.log"]
+

--- a/nss/curl/README.md
+++ b/nss/curl/README.md
@@ -1,0 +1,21 @@
+# Curl wolfPKCS11 Test
+
+## Introduction
+
+This is a Dockerfile test which builds Curl 8.0.0 (because it is was one of the last versions with NSS support) with NSS and builds wolfPKCS11. It configures NSS to use wolfPKCS11 instead of NSS's internal PKCS11 provider for cryptography calls.
+
+Some patches to NSS are applied to fix compatibility issues with third party PKCS11 providers and their source code.
+
+Whilst this is not intended for production use, this does make for a good simple demonstration of using wolfPKCS11 for web access.
+
+## Docker Usage
+
+You will need Docker installed and running to the script.
+
+To execute, the command is `run_wolfpkcs11_test.sh`. This will run NSS twice for a given URL, the first time it will log all PKCS11 mechanism calls to wolfPKCS11 and the second time it will log the mechanism calls to the internal NSS PKCS11 provider. It will then filter this to a unique list of calls made, the full logs will be made available in the `logs` subdirectory.
+
+You use `run_wolfpkcs11_test.sh` by providing a URL, such as:
+
+```sh
+./run_wolfpkcs11_test.sh https://example.com
+```

--- a/nss/curl/run_wolfpkcs11_test.sh
+++ b/nss/curl/run_wolfpkcs11_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <url>"
+    exit 1
+fi
+
+docker build -t nss-curl-wolfpkcs11 .
+
+mkdir -p ./logs
+chmod 777 ./logs
+
+docker run --rm -v "$(pwd)/logs:/logs" nss-curl-wolfpkcs11 sh -c "curl -o /dev/null -D - -s $1 || echo 'Curl exited with error code $?'"
+
+echo "Calls that used wolfPKCS11"
+grep -oP 'CKM_.+?\b' logs/nss.log | sort | uniq
+

--- a/nss/firefox/Dockerfile
+++ b/nss/firefox/Dockerfile
@@ -1,0 +1,72 @@
+FROM ubuntu:24.04
+
+# Set non-interactive mode for apt
+ENV DEBIAN_FRONTEND=noninteractive
+# Set wolf install path
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    mercurial \
+    gyp \
+    ninja-build \
+    pkg-config \
+    zlib1g-dev \
+    wget \
+    python3 \
+    python-is-python3 \
+    python3-pip \
+    autoconf \
+    automake \
+    libtool \
+    make \
+    gdb \
+    vim \
+    ca-certificates \
+    zlib1g-dev \
+    gettext \
+    llvm \
+    alsa \
+    libgtk-3-0 \
+    libasound2-dev \
+    libx11-xcb1
+
+RUN wget https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/main/python/mozboot/bin/bootstrap.py
+RUN python3 bootstrap.py --no-interactive --application-choice browser
+
+RUN git clone https://github.com/wolfssl/wolfssl.git
+WORKDIR /wolfssl
+RUN autoreconf -if
+RUN ./configure --enable-all --enable-aescfb --enable-cryptocb --enable-rsapss --enable-keygen \
+    --enable-pwdbased --enable-scrypt 'CFLAGS=-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT'
+RUN make && make install
+WORKDIR /
+
+RUN git clone https://github.com/wolfSSL/wolfPKCS11.git
+WORKDIR /wolfPKCS11
+RUN git checkout nss
+RUN autoreconf -if
+RUN ./configure --enable-rsa --enable-rsaoaep --enable-rsapss --enable-keygen --enable-ecc \
+    --enable-dh --enable-aes --enable-aeskeywrap --enable-aescbc --enable-aesgcm --enable-aesctr \
+    --enable-aesccm --enable-aesecb --enable-aescmac --enable-hmac --enable-md5 --enable-sha \
+    --enable-sha1 --enable-sha224 --enable-sha256 --enable-sha384 --enable-sha512 --enable-nss
+RUN make && make check && make install
+WORKDIR /
+
+RUN git clone https://github.com/wolfSSL/osp.git
+
+WORKDIR /firefox
+RUN git pull
+WORKDIR /firefox/security/nss
+RUN patch -p1 < /osp/nss/nss-ecc-curves.patch
+RUN patch -p1 < /osp/nss/nss-slot.patch
+WORKDIR /firefox
+RUN ./mach build
+RUN mkdir -p /firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default
+WORKDIR /firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default
+RUN echo library=libwolfpkcs11.so > pkcs11.txt
+RUN echo name=wolfPKCS11 >> pkcs11.txt
+RUN echo parameters=configdir='' certPrefix='' keyPrefix='' secmod='secmod.db' flags=optimizeSpace updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription='' >> pkcs11.txt
+RUN echo NSS=Flags=internal,critical cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] } >> pkcs11.txt
+WORKDIR /firefox

--- a/nss/firefox/README.md
+++ b/nss/firefox/README.md
@@ -1,0 +1,33 @@
+# wolfPCKS11 in Firefox
+
+## Introduction
+
+This builds Firefox with wolfPKCS11 as the crypto backend for NSS. Making all
+TLS connections in Firefox use wolfSSL.
+
+Note that the Docker build for this will require ~1GB of RAM per CPU core and
+will take a long time to build.
+
+## Scripts
+
+There are three scripts in this directory. All of them create debug builds, so
+performance will not be fantastic, but it is easier to see what is going on
+inside.
+
+Every script will build the Docker image (which will be skipped if it has
+already been built), before executing.
+
+### ff-window.sh
+
+This is intended to be run on a Linux host. It build and run Firefox inside a
+Docker image with wolfPKCS11 and use Xorg to show the Firefox window. This has
+been made compatible with Wayland hosts too.
+
+### ff-cli.sh
+
+This runs Firefox in headless mode.
+
+### ff-enter.sh
+
+This gives you a BASH prompt inside the Docker image once it has been built,
+so that it can be inspected and executed manually.

--- a/nss/firefox/ff-cli.sh
+++ b/nss/firefox/ff-cli.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+docker build -t ff-docker .
+
+ARGS="$@"
+
+docker run --rm	-w /firefox ff-docker sh -c "./mach run -- --headless $ARGS"

--- a/nss/firefox/ff-enter.sh
+++ b/nss/firefox/ff-enter.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+docker build -t ff-docker .
+
+docker run --rm -e DISPLAY=$DISPLAY --network=host -v /tmp/.X11-unix:/tmp/.X11-unix \
+	-w /firefox -it ff-docker bash
+
+

--- a/nss/firefox/ff-window.sh
+++ b/nss/firefox/ff-window.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+docker build -t ff-docker .
+
+ARGS="$@"
+
+xhost local:root
+
+docker run --rm -e DISPLAY=$DISPLAY --network=host -v /tmp/.X11-unix:/tmp/.X11-unix \
+	-w /firefox ff-docker sh -c "./mach run -- $ARGS"
+
+

--- a/nss/pdfsig/Dockerfile
+++ b/nss/pdfsig/Dockerfile
@@ -1,0 +1,117 @@
+FROM ubuntu:22.04
+
+# Set noninteractive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    mercurial \
+    python3 \
+    python-is-python3 \
+    python3-pip \
+    gyp \
+    ninja-build \
+    build-essential \
+    automake \
+    libtool \
+    git \
+    pkg-config \
+    poppler-utils \
+    wget \
+    enscript \
+    ghostscript \
+    gdb \
+    vim \
+    hexedit \
+    && rm -rf /var/lib/apt/lists/*
+
+#RUN update-ca-certificates
+
+RUN mkdir -p /src && \
+    cd /src && \
+    hg clone https://hg.mozilla.org/projects/nspr && \
+    hg clone https://hg.mozilla.org/projects/nss
+
+# Clone OSP for NSS patches
+WORKDIR /src
+RUN git clone https://github.com/wolfSSL/osp.git
+
+# Build NSS with debug mode enabled (debug is the default)
+WORKDIR /src/nss
+ENV USE_64=1
+ENV NSS_ENABLE_WERROR=0
+ENV BUILD_OPT=0
+
+# Checkout our branch
+RUN patch -p1 < /src/osp/nss/nss-ecc-curves.patch
+RUN patch -p1 < /src/osp/nss/nss-slot.patch
+
+# Build NSS with debug mode enabled (debug is the default)
+RUN ./build.sh -v
+
+RUN mkdir -p /usr/local/include/nss && \
+    mkdir -p /usr/local/include/nspr && \
+    # Copy NSS headers from dist directory
+    cp -r /src/dist/public/nss/* /usr/local/include/nss/ && \
+    # Copy NSPR headers from dist directory
+    cp -r /src/dist/Debug/include/nspr/* /usr/local/include/nspr/ && \
+    # Copy NSS and NSPR libraries
+    mkdir -p /usr/local/lib && \
+    find /src/dist/Debug -name "*.so" -exec cp {} /usr/local/lib/ \; && \
+    find /src/nspr/Debug -name "*.so" -exec cp {} /usr/local/lib/ \; && \
+    ldconfig
+
+# Create working directory
+WORKDIR /opt/wolfssl
+
+# Build wolfSSL
+RUN git clone https://github.com/wolfSSL/wolfssl.git && \
+    cd wolfssl && \
+    ./autogen.sh && \
+    ./configure --enable-aescfb --enable-cryptocb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-cmac --enable-aesctr --enable-aesccm C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -D_GNU_SOURCE" && \
+    make && \
+    make install && \
+    ldconfig
+
+# Clone and build wolfPKCS11 with NSS support
+WORKDIR /opt/wolfpkcs11
+RUN git clone https://github.com/wolfSSL/wolfPKCS11.git && \
+    cd wolfPKCS11 && \
+    git checkout nss && \
+    ./autogen.sh && \
+    ./configure --enable-debug --enable-nss --enable-aesecb --enable-aesctr --enable-aesccm --enable-aescmac CFLAGS="-D_GNU_SOURCE" && \
+    make && \
+    make install && \
+    ldconfig
+
+# Create directory for NSS configuration
+RUN mkdir -p /etc/pki/nssdb
+
+# Configure NSS to use wolfPKCS11
+RUN echo "library=/usr/local/lib/libwolfpkcs11.so" > /etc/pki/nssdb/pkcs11.txt && \
+    echo "name=wolfPKCS11" >> /etc/pki/nssdb/pkcs11.txt && \
+    echo "NSS=Flags=internal,critical,fips cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] }" >> /etc/pki/nssdb/pkcs11.txt
+
+# Create directory for PDF operations
+RUN mkdir -p /opt/pdf
+
+# Set working directory for PDF operations
+WORKDIR /opt/pdf
+
+# Add a script to generate, sign, and verify a PDF
+COPY pdf_operations.sh /opt/pdf/
+RUN chmod +x /opt/pdf/pdf_operations.sh
+
+# Set NSS debug environment variables
+ENV NSS_DEBUG_PKCS11_MODULE="wolfPKCS11"
+ENV NSPR_LOG_MODULES="all:5"
+ENV NSPR_LOG_FILE=/logs/nss.log
+ENV NSS_OUTPUT_FILE=/logs/stats.log
+ENV NSS_STRICT_NOFORK=1
+ENV NSS_DEBUG=all
+
+RUN mkdir /logs
+
+
+# Set entrypoint to the PDF operations script
+ENTRYPOINT ["/opt/pdf/pdf_operations.sh"]

--- a/nss/pdfsig/README.md
+++ b/nss/pdfsig/README.md
@@ -1,0 +1,31 @@
+# wolfPKCS11 with NSS for PDF Signing
+
+## Introuction
+
+This Dockerfile creates an environment that:
+
+1. Takes the `nss` branch of wolfPKCS11
+2. Compiles it with `--enable-nss`
+3. Configures NSS to use wolfPKCS11
+4. Generates a PDF file
+5. Signs the PDF file with `pdfsig`
+6. Verifies the signature with `pdfsig`
+
+`pdfsig` uses `libpoppler` which in-turn uses NSS for signing PDF files.
+
+## Building and Running
+
+With Docker running on your system, simply run `./run_wolfpkcs11_test.sh`. This
+will build the Docker image and then execute it.
+
+## Output
+
+The container will:
+1. Configure NSS to use wolfPKCS11
+2. Generate a self-signed certificate for PDF signing
+3. Create a simple PDF file
+4. Sign the PDF with pdfsig
+5. Verify the signature with pdfsig
+6. Display detailed signature information
+
+The signed PDF will be available at `/opt/pdf/signed.pdf` inside the container.

--- a/nss/pdfsig/pdf_operations.sh
+++ b/nss/pdfsig/pdf_operations.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# set -e
+
+echo "Starting PDF operations with wolfPKCS11 and NSS..."
+
+echo "Checking wolfPKCS11 library..."
+if [ -f /usr/local/lib/libwolfpkcs11.so ]; then
+    echo "wolfPKCS11 library found at /usr/local/lib/libwolfpkcs11.so"
+    ls -la /usr/local/lib/libwolfpkcs11.so
+    ldd /usr/local/lib/libwolfpkcs11.so || echo "Failed to run ldd on libwolfpkcs11.so"
+else
+    echo "ERROR: wolfPKCS11 library not found at /usr/local/lib/libwolfpkcs11.so"
+    find /usr -name "libwolfpkcs11.so"
+fi
+
+echo "Checking wolfSSL library..."
+if [ -f /usr/local/lib/libwolfssl.so ]; then
+    echo "wolfSSL library found at /usr/local/lib/libwolfssl.so"
+    ls -la /usr/local/lib/libwolfssl.so
+else
+    echo "ERROR: wolfSSL library not found at /usr/local/lib/libwolfssl.so"
+    find /usr -name "libwolfssl.so"
+fi
+
+echo "Configuring NSS to use wolfPKCS11..."
+mkdir -p /etc/pki/nssdb
+chmod 755 /etc/pki/nssdb
+
+cat > /etc/pki/nssdb/pkcs11.txt << 'EOF'
+library=/usr/local/lib/libwolfpkcs11.so
+name=wolfPKCS11
+NSS=Flags=internal,critical,fips cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] }
+EOF
+
+/src/dist/Debug/bin/certutil -N -d /etc/pki/nssdb/ --empty-password
+
+echo "* Generating self-signed certificate for PDF signing..."
+/src/dist/Debug/bin/certutil -d /etc/pki/nssdb -S -n "PDF Signing Certificate" -s "CN=PDF Signer,O=wolfSSL,C=US" -x -t "CT,C,C" -v 120 -g 2048 -z pdf_operations.sh
+
+echo "* Generating a simple PDF file..."
+cat > test.txt << EOF
+This is a test document for PDF signing with wolfPKCS11 and NSS.
+Generated on $(date)
+EOF
+
+echo "* Converting text to PDF..."
+cat test.txt | enscript -B -o - | ps2pdf - test.pdf || echo "Failed to generate PDF"
+
+if [ -f test.pdf ]; then
+    echo "PDF generation successful!"
+    ls -la test.pdf
+else
+    echo "PDF generation failed!"
+fi
+
+echo "* Signing the PDF file..."
+echo "An NSS shutdown error is normal here"
+pdfsig test.pdf signed.pdf -add-signature -nick "PDF Signing Certificate" -nssdir /etc/pki/nssdb
+
+echo "* Verifying the PDF signature..."
+pdfsig signed.pdf -nssdir /etc/pki/nssdb
+
+echo "PDF operations completed successfully!"
+
+if [ "$1" = "keep-running" ]; then
+    echo "Container will keep running. Use Ctrl+C to stop."
+    tail -f /dev/null
+fi

--- a/nss/pdfsig/run_wolfpkcs11_test.sh
+++ b/nss/pdfsig/run_wolfpkcs11_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build -t wolfpkcs11-nss-pdf .
+docker run -t wolfpkcs11-nss-pdf .
+


### PR DESCRIPTION
This adds examples for wolfPKCS11 as the crypto backend for NSS. The examples are:

* Curl (version 8.0)
* pdfsig
* Firefox

Note: for now these use the "nss" feature branch of wolfPKCS11. This can be changed once this branch has been merged to master.