### PR TITLE
Firefox update

### DIFF
--- a/nss/firefox/Dockerfile
+++ b/nss/firefox/Dockerfile
@@ -76,10 +76,11 @@ WORKDIR /home/ubuntu/firefox/security/nss
 RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-tests-2025-04-11-978205bd37c33d862a5798d8158df7091412d3a7.patch
 WORKDIR /home/ubuntu/firefox
 RUN ./mach build
-RUN mkdir -p /home/ubuntu/firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default
-WORKDIR /home/ubuntu/firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default
-RUN echo library=libwolfpkcs11.so > pkcs11.txt
-RUN echo name=wolfPKCS11 >> pkcs11.txt
-RUN echo parameters=configdir='sql:/home/ubuntu/firefox/docker-local/firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default' certPrefix='' keyPrefix='' secmod='secmod.db' flags=optimizeSpace updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription='' >> pkcs11.txt
-RUN echo NSS=Flags=internal,critical cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] } >> pkcs11.txt
+RUN OBJ_DIR=$(ls -d obj-*/dist/bin/firefox | head -1 | cut -d/ -f1) && \
+    mkdir -p /home/ubuntu/firefox/$OBJ_DIR/tmp/profile-default && \
+    cd /home/ubuntu/firefox/$OBJ_DIR/tmp/profile-default && \
+    echo "library=libwolfpkcs11.so" > pkcs11.txt && \
+    echo "name=wolfPKCS11" >> pkcs11.txt && \
+    echo "parameters=configdir='sql:/home/ubuntu/firefox/$OBJ_DIR/tmp/profile-default' certPrefix='' keyPrefix='' secmod='secmod.db' flags=optimizeSpace updatedir='' updateCertPrefix='' updateKeyPrefix='' updateid='' updateTokenDescription=''" >> pkcs11.txt && \
+    echo "NSS=Flags=internal,critical cipherOrder=100 slotParams={0x00000001=[slotFlags=ECC,RSA,DSA,DH,RC2,RC4,DES,RANDOM,SHA1,MD5,MD2,SSL,TLS,AES,Camellia,SEED,SHA256,SHA512] }" >> pkcs11.txt
 WORKDIR /home/ubuntu/firefox

--- a/nss/firefox/Dockerfile
+++ b/nss/firefox/Dockerfile
@@ -73,6 +73,7 @@ RUN git clone https://github.com/wolfSSL/osp.git
 WORKDIR /home/ubuntu/firefox
 RUN git checkout $FIREFOX_TAG
 WORKDIR /home/ubuntu/firefox/security/nss
+RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-fixes-2025-04-11-978205bd37c33d862a5798d8158df7091412d3a7.patch
 RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-tests-2025-04-11-978205bd37c33d862a5798d8158df7091412d3a7.patch
 WORKDIR /home/ubuntu/firefox
 RUN ./mach build

--- a/nss/firefox/Dockerfile
+++ b/nss/firefox/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG FIREFOX_TAG=78c455227887c316bdde0be2738e31fcecb4547d
+
 # Set non-interactive mode for apt
 ENV DEBIAN_FRONTEND=noninteractive
 # Set wolf install path
@@ -69,10 +71,9 @@ WORKDIR /home/ubuntu/src
 RUN git clone https://github.com/wolfSSL/osp.git
 
 WORKDIR /home/ubuntu/firefox
-RUN git pull
+RUN git checkout $FIREFOX_TAG
 WORKDIR /home/ubuntu/firefox/security/nss
-RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-ecc-curves.patch
-RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-slot.patch
+RUN patch -p1 < /home/ubuntu/src/osp/nss/nss-tests-2025-04-11-978205bd37c33d862a5798d8158df7091412d3a7.patch
 WORKDIR /home/ubuntu/firefox
 RUN ./mach build
 RUN mkdir -p /home/ubuntu/firefox/obj-x86_64-pc-linux-gnu/tmp/profile-default


### PR DESCRIPTION
Update the Firefox Docker image:

* Pin the version of Firefox to one where the patches will work
* Update the paths for the NSS patches
* Make the build CPU agnostic (tested on an ARM64 Linux host)